### PR TITLE
Multiple fixups and tuning

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('tssupervisorupdate', 'c', version: '1.0.2')
+project('tssupervisorupdate', 'c', version: '1.1.0')
 add_project_arguments('-DTAG="' + meson.project_version() + '"', language: 'c')
 executable('tssupervisorupdate', 
   [

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,5 @@
-project('tssupervisorupdate', 'c')
+project('tssupervisorupdate', 'c', version: '1.0.2')
+add_project_arguments('-DTAG="' + meson.project_version() + '"', language: 'c')
 executable('tssupervisorupdate', 
   [
     'tssupervisorupdate.c',

--- a/micro.c
+++ b/micro.c
@@ -19,9 +19,9 @@ int micro_init(int i2cbus, int i2caddr)
 
 	snprintf(i2c_bus_path, sizeof(i2c_bus_path), "/dev/i2c-%d", i2cbus);
 	fd = open(i2c_bus_path, O_RDWR);
-	if (fd == -1) {
+	if (fd < 0) {
 		perror("Couldn't open i2c device");
-		exit(1);
+		goto out;
 	}
 
 	/*
@@ -30,9 +30,11 @@ int micro_init(int i2cbus, int i2caddr)
 	 */
 	if (ioctl(fd, I2C_SLAVE_FORCE, i2caddr) < 0) {
 		perror("Supervisor did not ACK");
-		exit(1);
+		close(fd);
+		fd = -1;
 	}
 
+out:
 	return fd;
 }
 

--- a/micro.c
+++ b/micro.c
@@ -9,8 +9,6 @@
 #include <linux/i2c.h>
 #include <linux/i2c-dev.h>
 
-#include "micro.h"
-
 int micro_init(int i2cbus, int i2caddr)
 {
 	static int fd = -1;
@@ -31,40 +29,22 @@ int micro_init(int i2cbus, int i2caddr)
 	 * safe because we are using only i2c_msgs and not read()/write() calls
 	 */
 	if (ioctl(fd, I2C_SLAVE_FORCE, i2caddr) < 0) {
-		perror("Supervisor did not ACK\n");
+		perror("Supervisor did not ACK");
 		exit(1);
 	}
 
 	return fd;
 }
 
-void spoke16(int i2cfd, int i2caddr, uint16_t addr, uint16_t data)
-{
-	int ret;
-
-	ret = spokestream16(i2cfd, i2caddr, addr, &data, 2);
-	if (ret) {
-		perror("Failed to write to supervisory micro");
-		exit(1);
-	}
-}
-
-uint16_t speek16(int i2cfd, int i2caddr, uint16_t addr)
-{
-	uint16_t data = 0;
-	int ret = speekstream16(i2cfd, i2caddr, addr, &data, 2);
-
-	if (ret) {
-		perror("Failed to read from supervisory micro");
-		exit(1);
-	}
-	return data;
-}
-
-int speekstream16(int i2cfd, int i2caddr, uint16_t addr, uint16_t *data, int size)
+/*
+ * Returns < 0 on failure, 0 on success
+ * Data read is inserted in to *data
+ */
+int speekstream16(int i2cfd, uint16_t i2caddr, uint16_t addr, uint16_t *data, uint16_t size)
 {
 	struct i2c_rdwr_ioctl_data packets;
 	struct i2c_msg msgs[2];
+	int ret;
 
 	msgs[0].addr = i2caddr;
 	msgs[0].flags = 0;
@@ -79,24 +59,37 @@ int speekstream16(int i2cfd, int i2caddr, uint16_t addr, uint16_t *data, int siz
 	packets.msgs = msgs;
 	packets.nmsgs = 2;
 
-	if (ioctl(i2cfd, I2C_RDWR, &packets) < 0) {
-		perror("Unable to send data");
-		return 1;
-	}
-	return 0;
+	/* I2C_RDWR will return < 0 on error, or the number of messages that
+	 * were transferred. We should always have two since we are only ever
+	 * sending a write followed by a read.
+	 */
+	ret = ioctl(i2cfd, I2C_RDWR, &packets);
+	if (ret < 0)
+		perror("Unable to read data");
+	else if (ret == 2)
+		ret = 0;
+	else
+		ret = -1;
+
+	return ret;
 }
 
-int spokestream16(int i2cfd, int i2caddr, uint16_t addr, uint16_t *data, int size)
+/*
+ * Returns < 0 on failure, 0 on success
+ */
+int spokestream16(int i2cfd, uint16_t i2caddr, uint16_t addr, uint16_t *data, uint16_t size)
 {
 	struct i2c_rdwr_ioctl_data packets;
 	struct i2c_msg msg;
-	uint8_t outdata[4096];
+	uint8_t *outdata;
+	int ret;
 
 	/*
 	 * Linux only supports 4k transactions at a time, and we need
 	 * two bytes for the address
 	 */
 	assert(size <= 4094);
+	outdata = malloc(size + 2);
 
 	memcpy(outdata, &addr, 2);
 	memcpy(&outdata[2], data, size);
@@ -109,51 +102,80 @@ int spokestream16(int i2cfd, int i2caddr, uint16_t addr, uint16_t *data, int siz
 	packets.msgs = &msg;
 	packets.nmsgs = 1;
 
-	if (ioctl(i2cfd, I2C_RDWR, &packets) < 0)
-		return 1;
-	return 0;
-}
+	ret = ioctl(i2cfd, I2C_RDWR, &packets);
+	free(outdata);
 
-int v0_stream_read(int twifd, int i2caddr, uint8_t *data, int bytes)
-{
-	struct i2c_rdwr_ioctl_data packets;
-	struct i2c_msg msg;
-	int retry = 0;
-
-retry:
-	msg.addr = i2caddr;
-	msg.flags = I2C_M_RD;
-	msg.len = bytes;
-	msg.buf = data;
-
-	packets.msgs = &msg;
-	packets.nmsgs = 1;
-
-	if (ioctl(twifd, I2C_RDWR, &packets) < 0) {
-		perror("Unable to read data");
-		retry++;
-		if (retry < 10)
-			goto retry;
-	}
-	return 0;
-}
-
-int v0_stream_write(int twifd, int i2caddr, uint8_t *data, int bytes)
-{
-	struct i2c_rdwr_ioctl_data packets;
-	struct i2c_msg msg;
-
-	msg.addr = i2caddr;
-	msg.flags = 0;
-	msg.len = bytes;
-	msg.buf = data;
-
-	packets.msgs = &msg;
-	packets.nmsgs = 1;
-
-	if (ioctl(twifd, I2C_RDWR, &packets) < 0) {
+	/* I2C_RDWR will return < 0 on error, or the number of messages that
+	 * were transferred. We should always have one since we are only ever
+	 * sending a single transfer.
+	 */
+	if (ret < 0)
 		perror("Unable to send data");
-		return 1;
-	}
-	return 0;
+	else if (ret == 1)
+		ret = 0;
+	else
+		ret = -1;
+
+	return ret;
+}
+
+/*
+ * Since we are not expecting any data, simply pass along the return value
+ * of the stream write.
+ *
+ * < 0 on failure, 0 on success
+ */
+int spoke16(int i2cfd, uint16_t i2caddr, uint16_t addr, uint16_t data)
+{
+	return spokestream16(i2cfd, i2caddr, addr, &data, 2);
+}
+
+/*
+ * Returns < 0 on failure
+ */
+int speek16(int i2cfd, uint16_t i2caddr, uint16_t addr, uint16_t *data)
+{
+	return speekstream16(i2cfd, i2caddr, addr, data, 2);
+}
+
+/*
+ * Returns 0 on success, < 0 on all other failures.
+ */
+static int __v0_stream(int twifd, uint16_t i2caddr, uint8_t *data, uint16_t bytes, uint16_t flags)
+{
+	struct i2c_rdwr_ioctl_data packets;
+	struct i2c_msg msg;
+	int ret = 0;
+
+	msg.addr = i2caddr;
+	msg.flags = flags;
+	msg.len = bytes;
+	msg.buf = data;
+
+	packets.msgs = &msg;
+	packets.nmsgs = 1;
+
+	/* I2C_RDWR will return < 0 on error, or the number of messages that
+	 * were transferred. We should always have one since we are only ever
+	 * sending a single transfer.
+	 */
+	ret = ioctl(twifd, I2C_RDWR, &packets);
+	if (ret < 0)
+		perror("Unable to transfer data");
+	else if (ret == 1)
+		ret = 0;
+	else
+		ret = -1;
+
+	return ret;
+}
+
+int v0_stream_read(int twifd, uint16_t i2caddr, uint8_t *data, uint16_t bytes)
+{
+	return __v0_stream(twifd, i2caddr, data, bytes, I2C_M_RD);
+}
+
+int v0_stream_write(int twifd, uint16_t i2caddr, uint8_t *data, uint16_t bytes)
+{
+	return __v0_stream(twifd, i2caddr, data, bytes, 0);
 }

--- a/micro.h
+++ b/micro.h
@@ -1,23 +1,9 @@
 #pragma once
 
-int speekstream16(int i2cfd, int i2caddr, uint16_t addr, uint16_t *data, int size);
-int spokestream16(int i2cfd, int i2caddr, uint16_t addr, uint16_t *data, int size);
-int micro_init(int i2cbus, int i2caddr);
-void spoke16(int i2cfd, int i2caddr, uint16_t addr, uint16_t data);
-uint16_t speek16(int i2cfd, int i2caddr, uint16_t addr);
-int v0_stream_write(int i2cfd, int i2caddr, uint8_t *data, int bytes);
-int v0_stream_read(int i2cfd, int i2caddr, uint8_t *data, int bytes);
-
-typedef enum update_method {
-	UPDATE_V0,
-	UPDATE_V1,
-} update_meth_t;
-
-typedef struct board {
-	const char *compatible;
-	uint16_t modelnum;
-	int i2c_bus;
-	int i2c_chip;
-	update_meth_t method;
-} board_t;
-
+int speekstream16(int i2cfd, uint16_t i2caddr, uint16_t addr, uint16_t *data, uint16_t size);
+int spokestream16(int i2cfd, uint16_t i2caddr, uint16_t addr, uint16_t *data, uint16_t size);
+int micro_init(int i2cbus, uint16_t i2caddr);
+int spoke16(int i2cfd, uint16_t i2caddr, uint16_t addr, uint16_t data);
+int speek16(int i2cfd, uint16_t i2caddr, uint16_t addr, uint16_t *data);
+int v0_stream_write(int i2cfd, uint16_t i2caddr, uint8_t *data, uint16_t bytes);
+int v0_stream_read(int i2cfd, uint16_t i2caddr, uint8_t *data, uint16_t bytes);

--- a/tssupervisorupdate.c
+++ b/tssupervisorupdate.c
@@ -1,5 +1,4 @@
 #include <errno.h>
-#include <error.h>
 #include <fcntl.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/tssupervisorupdate.c
+++ b/tssupervisorupdate.c
@@ -87,6 +87,7 @@ void usage(char **argv)
 		"  -u, --update <file>    Update file.\n"
 		"  -b, --bus              Override default i2c bus\n"
 		"  -c, --chip-addr        Override default i2c chip address\n"
+		"  -v, --version          Print version\n"
 		"  -h, --help             This message\n"
 		"\n",
 		argv[0]);
@@ -120,17 +121,18 @@ int main(int argc, char *argv[])
 						{ "dry-run", no_argument, NULL, 'n' },
 						{ "chip-addr", required_argument, NULL, 'c' },
 						{ "bus", required_argument, NULL, 'b' },
+						{ "version", no_argument, NULL, 'v' },
 						{ "help", no_argument, NULL, 'h' },
 						{ 0, 0, 0, 0 } };
 
-	while ((c = getopt_long(argc, argv, "u:nihfc:b:", long_options, &option_index)) != -1) {
+	while ((c = getopt_long(argc, argv, "u:nihfc:b:v", long_options, &option_index)) != -1) {
 		switch (c) {
 		case 'f':
 			force_flag = 1;
 			break;
 		case 'h':
 			usage(argv);
-			break;
+			return 0;
 		case 'i':
 			info_flag = 1;
 			break;
@@ -146,6 +148,9 @@ int main(int argc, char *argv[])
 		case 'u':
 			update_path = optarg;
 			break;
+		case 'v':
+			printf("tssupervisorupdate %s\n", TAG);
+			return 0;
 		case '?':
 		default:
 			printf("Unexpected argument \"%s\"\n", optarg);

--- a/tssupervisorupdate.c
+++ b/tssupervisorupdate.c
@@ -170,10 +170,10 @@ int main(int argc, char *argv[])
 	if (opt_bus != -1)
 		board->i2c_bus = opt_bus;
 
-	int (*update_func)(board_t *board, int i2cfd, char *update_path) = NULL;
-	int (*get_rev_func)(board_t *board, int i2cfd, int *revision) = NULL;
-	int (*get_update_rev_func)(board_t *board, int *revision, char *update_path) = NULL;
-	int (*print_micro_info_func)(board_t *board, int i2cfd) = NULL;
+	int (*update_func)(board_t * board, int i2cfd, char *update_path) = NULL;
+	int (*get_rev_func)(board_t * board, int i2cfd, int *revision) = NULL;
+	int (*get_update_rev_func)(board_t * board, int *revision, char *update_path) = NULL;
+	int (*print_micro_info_func)(board_t * board, int i2cfd) = NULL;
 
 	switch (board->method) {
 	case UPDATE_V0:

--- a/update-shared.h
+++ b/update-shared.h
@@ -10,6 +10,7 @@ typedef struct board {
 	uint16_t modelnum;
 	int i2c_bus;
 	int i2c_chip;
+	uint16_t min_rev;
 	update_meth_t method;
 } board_t;
 

--- a/update-shared.h
+++ b/update-shared.h
@@ -1,5 +1,18 @@
 #pragma once
 
+typedef enum update_method {
+	UPDATE_V0,
+	UPDATE_V1,
+} update_meth_t;
+
+typedef struct board {
+	const char *compatible;
+	uint16_t modelnum;
+	int i2c_bus;
+	int i2c_chip;
+	update_meth_t method;
+} board_t;
+
 void flash_print_error(uint8_t status);
 
 /* Read-back status values */

--- a/update-v0.h
+++ b/update-v0.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "update-shared.h"
+
 int do_v0_micro_update(board_t *board, int i2cfd, char *update_path);
 int do_v0_micro_get_rev(board_t *board, int i2cfd, int *revision);
 int do_v0_micro_get_file_rev(board_t *board, int *revision, char *update_path);

--- a/update-v1.h
+++ b/update-v1.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "update-shared.h"
+
 int do_v1_micro_update(board_t *board, int i2cfd, char *update_path);
 int do_v1_micro_get_rev(board_t *board, int i2cfd, int *revision);
 int do_v1_micro_get_file_rev(board_t *board, int *revision, char *update_path);


### PR DESCRIPTION
Intended to fix sporadic issues on TS-7970 programming, ended up cleaning up a few latent issues and tackling some Issues.

## High level important fixes
- Timeout after writes increased to a calculated length with extra margins added. Previous timeouts were empirically gathered and were not sufficient on random occasions.
- Remove last remaining uses of `read()` and `write()` on the i2cdev file, now uniformly `ioctl()` based.
- Normalized function returns values -- Main application will return 0 on success, 1 on failure. All functions return 0 on success, -1 on failure. Library functions that set errno have a call to `perror()` with higher level functions only following up with more detail on stderr if relevant.
- Added limits to loops that could spin forever in the case of a failure.
- Fixed #4
- Fixed #3

## Testing
Tested on both a TS-7970 Rev. H as well as a TS-7250-V3 Rev. C. Both were set up with a modified Image Replicator image that would boot, write the latest image, reboot, write an older image, reboot, repeat.

TS-7970 being the more problematic of the two, has been running against these latest changes for a cumulative total of about ~~48~~ 96 hours with no stalls or failures to program.

The TS-7250-V3, having not had any prior issues, was tested with the latest changes for about ~~6~~ 50 hours in total with no issues.

As per #3, build of this codebase was done pre and post fix using Image Replicator buildroot modified to build against musl. The pre fix failed as expected, and post-fix built fully.