### PR TITLE
tssupervisorupdate: use I2C bus 3 on TS-9370.

### DIFF
--- a/tssupervisorupdate.c
+++ b/tssupervisorupdate.c
@@ -67,7 +67,7 @@ board_t boards[] = {
 		.compatible = "technologic,ts9370",
 		.modelnum = 0x9370,
 		.compatible_id = 0x9370,
-		.i2c_bus = 0,
+		.i2c_bus = 3,
 		.i2c_chip = 0x54,
 		.method = UPDATE_V1,
 	},


### PR DESCRIPTION
After P3 this i2c bus was changed.